### PR TITLE
Improve roulette wheel readability

### DIFF
--- a/roulette.html
+++ b/roulette.html
@@ -6,15 +6,19 @@
   <title>Roulette App</title>
   <style>
     body {
-      font-family: Arial, sans-serif;
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
       text-align: center;
       margin-top: 50px;
+      background-color: #f9f9f9;
     }
+
     canvas {
-      border: 2px solid #000;
+      border: 2px solid #333;
       margin: 20px auto;
       display: block;
+      border-radius: 50%;
     }
+
     button {
       padding: 10px 20px;
       font-size: 16px;
@@ -46,7 +50,7 @@
     let startAngle = 0;
     let arc = 0;
 
-    const colors = ["#FF5733", "#33FF57", "#3357FF", "#F3FF33", "#FF33A8"];
+    const colors = ["#ffad60", "#6ec1e4", "#a2d5c6", "#f7dd72", "#d675ad"];
 
     function drawRouletteWheel() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -62,7 +66,8 @@
         ctx.arc(canvas.width / 2, canvas.height / 2, insideRadius, angle + arc, angle, true);
         ctx.fill();
         ctx.save();
-        ctx.fillStyle = "#000";
+        ctx.fillStyle = "#333";
+        ctx.font = "bold 20px Arial";
         ctx.translate(
           canvas.width / 2 + Math.cos(angle + arc / 2) * textRadius,
           canvas.height / 2 + Math.sin(angle + arc / 2) * textRadius


### PR DESCRIPTION
## Summary
- refine the page style with modern fonts and subtle colors
- use a softer palette for wheel segments
- enlarge name text on the wheel for better readability

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841a99768bc832fae7f82871ae1038c